### PR TITLE
Fixed rdaInit

### DIFF
--- a/RDA1846.cpp
+++ b/RDA1846.cpp
@@ -183,7 +183,7 @@ void RDA1846::rdaInit(void) {
   Serial.println("--DEBUG: rdaInit Print---");
 #endif
   for(int x=0; x<30; x++) {
-    writeWord(RDAinit[x].reg, RDAinit[x].data);
+    writeWord(RDAinit[x].data, RDAinit[x].reg);
 #ifdef DEBUGPRINT
     Serial.print(x);
 	Serial.print(":");


### PR DESCRIPTION
The parameters of method writeWord were swapped in order, so the rdaInit function would not work correctly.
